### PR TITLE
update env var name in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ ARG mmonit_url=https://mmonit.com/dist/mmonit-${mmonit_version}-linux-${mmonit_a
 
 ENV \
 	MMONIT_VERSION=$mmonit_version \
-        MMONIT_DATABSE_URL= \
+	MMONIT_DATABASE_URL= \
 	MMONIT_LICENSE_OWNER= \
 	MMONIT_LICENSE_KEY= \
 	MMOUNT_DATABASE_URL= \
-        MMONIT_LIMIT_FD=4096 \
+	MMONIT_LIMIT_FD=4096 \
 	MMONIT_TLS_VERSION= \
 	TZ=UTC
 


### PR DESCRIPTION
update Dockerfile too, last commit missed the wrong spelling there.
Commit not really needed to work but without this PR the wrong env var name is printend on startup (being empty everytime)